### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {metosin/malli {:mvn/version "0.2.0"}}}


### PR DESCRIPTION
I think adding a deps.edn will allow users to have a conrete dependency on your repo (a specific sha) instead relying on clojar releases.