### PR TITLE
Add support for ignore-unknown-events flag

### DIFF
--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -734,11 +734,12 @@
         atomic-nodes (filter #(= (:type %) :atomic) configuration)
         txs (->> atomic-nodes
                  (map #(select-one-tx fsm % state event input-event)))
-        _ (when-not (->> txs
+        _ (when-not ignore-unknown-event?
+            (when-not (->> txs
                          (map first)
                          (some identity))
-            (throw (ex-info (str "fsm " (:id fsm) " got unknown event " (:type event))
-                            {:_state _state})))
+              (throw (ex-info (str "fsm " (:id fsm) " got unknown event " (:type event))
+                              {:_state _state}))))
         txs (->> txs
                  (map second)
                  (remove nil?))]

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -938,6 +938,23 @@
 
       )))
 
+(deftest test-ignore-unknown-event
+  (let [fsm (impl/machine {:id :foo
+                           :initial :foo
+                           :states {:foo {:on {:foo-event {:target :bar}}}
+                                    :bar {:on {:bar-event {:target :foo}}}}})
+        state (impl/initialize fsm)]
+    (testing "error is thrown when flag is unset"
+      (is (thrown? #?(:clj Exception
+                      :cljs js/Error)
+                   (impl/transition fsm state :bar-event))))
+    (testing "error is thrown when flag is false"
+      (is (thrown? #?(:clj Exception
+                      :cljs js/Error)
+                   (impl/transition fsm state :bar-event {:ignore-unknown-event? false}))))
+    (testing "error is not thrown when flag is true"
+      (is (= :foo (:_state (impl/transition fsm state :bar-event {:ignore-unknown-event? true})))))))
+
 (deftest test-parallel-regions-without-state
   (let [fsm (impl/machine {:id :foo
                            :type :parallel

--- a/test/statecharts/service_test.cljc
+++ b/test/statecharts/service_test.cljc
@@ -65,3 +65,13 @@
         (advance-clock 500)
         (is-x 3))
       ))
+
+(deftest test-transition-opts
+  (let [machine (fsm/machine {:id :foo
+                              :initial :foo
+                              :states {:foo {:on {:foo-event {:target :bar}}}
+                                       :bar {:on {:bar-event {:target :foo}}}}})
+        svc (fsm/service machine {:transition-opts {:ignore-unknown-event? true}})]
+    (fsm/start svc)
+    (testing "error is not thrown when ignore-unknown-event? flag is set"
+      (is (= :foo (:_state (fsm/send svc :bar-event)))))))


### PR DESCRIPTION
Hello!

I noticed there was a `:ignore-unknown-event?` flag in the `fsm/transition` call but it wasn't being used to disable the error throw when the event is unknown.

This PR adds support for that flag.

Also, I wanted to expose that flag so that it can be used with the Service. I added an optional `:transition-opts` that is passed in when creating the Service and will be passed to the `fsm/transition` call by the Service. I'm not sure if this is ideal, though. Maybe I should instead add another arity to the `service/send` method so the opts can be passed there?