### PR TITLE
Add re-frame integration that allows one machine to manage several states

### DIFF
--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -229,7 +229,7 @@
    state
    transition-event
    {:as internal-action :keys [action event event-delay]}]
-  (let [scheduler (or (:scheduler state) (:scheduler fsm))]
+  (let [scheduler (or (:_scheduler state) (:scheduler fsm))]
     (when-not scheduler
       (throw (ex-info
               "Delayed fsm without scheduler configured"

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -166,10 +166,6 @@
      [:map
       [:path any?]
       [:transition-event {:optional true} keyword?]
-      [:initialize-event {:optional true} keyword?]]]
-    [:re-frame-multi {:optional true}
-     [:map
-      [:transition-event {:optional true} keyword?]
       [:initialize-event {:optional true} keyword?]]]]])
 
 (def T_Machine

--- a/src/statecharts/integrations/re_frame_multi.cljc
+++ b/src/statecharts/integrations/re_frame_multi.cljc
@@ -1,0 +1,66 @@
+(ns statecharts.integrations.re-frame-multi
+  "Integration with re-frame, allowing one machine to manage multiple states."
+  (:require [re-frame.core :as rf]
+            [statecharts.core :as fsm]
+            [statecharts.clock :as clock]
+            [statecharts.utils :as u]
+            [statecharts.delayed :as fsm.d]
+            [statecharts.service :as service]))
+
+(rf/reg-event-fx
+ ::call-fx
+ (fn [_ [_ fx]]
+   fx))
+
+(defn call-fx
+  "Dispatch the provided effects."
+  [effects]
+  (rf/dispatch [::call-fx effects]))
+
+(defn fx-action
+  "Create an action that when called would dispatch the provided
+  effects."
+  [effects]
+  (fn []
+    (rf/dispatch [::call-fx effects])))
+
+(defn rf-transition-scheduler [transition-event transition-data clock]
+  (fsm.d/make-scheduler (fn [delay-event & _more]
+                          (rf/dispatch [transition-event delay-event transition-data]))
+                        clock))
+
+(defn default-opts []
+  {:clock (clock/wall-clock)})
+
+(defn integrate
+  ([machine]
+   (integrate machine default-opts))
+  ([{:keys [integrations] :as machine} {:keys [clock] :or {clock (clock/wall-clock)}}]
+   (let [{:keys [initialize-event transition-event]} (:re-frame-multi integrations)]
+     (when initialize-event
+       (rf/reg-event-db
+        initialize-event
+        (fn [db [_ {:keys [state-path] :as transition-data} initialize-args]]
+          ;; the context holds its own scheduler, which dispatches back with the
+          ;; same transition-data
+          (let [scheduler (rf-transition-scheduler transition-event transition-data clock)
+                initialize-args (assoc-in initialize-args [:context :scheduler] scheduler)]
+            (assoc-in db (u/ensure-vector state-path)
+                      (fsm/initialize machine initialize-args))))))
+
+     (when transition-event
+       (rf/reg-event-db
+        transition-event
+        (fn [db [_ fsm-event {:keys [state-path] :as transition-data} data & more-data]]
+          (when-not state-path
+            (throw (ex-info "cannot transition without :state-path" transition-data)))
+          (let [fsm-event  (u/ensure-event-map fsm-event)
+                state-path (u/ensure-vector state-path)
+                state      (get-in db state-path)]
+            (update-in db state-path
+                       (fn [state]
+                         (fsm/transition machine state
+                                         (cond-> (assoc fsm-event :data data)
+                                           (some? more-data)
+                                           (assoc :more-data more-data)))))))))
+     machine)))

--- a/src/statecharts/integrations/re_frame_multi.cljc
+++ b/src/statecharts/integrations/re_frame_multi.cljc
@@ -102,7 +102,7 @@
        ;; same path-data
        (let [scheduler       (rf-transition-scheduler path-data (or clock (clock/wall-clock)))
              initialize-args (update initialize-args :context assoc
-                                     :scheduler scheduler
+                                     :_scheduler scheduler
                                      :_epoch (:_epoch machine))]
          {:db (assoc-in db state-path (fsm/initialize machine initialize-args))})))))
 

--- a/src/statecharts/integrations/re_frame_multi.cljc
+++ b/src/statecharts/integrations/re_frame_multi.cljc
@@ -1,6 +1,7 @@
 (ns statecharts.integrations.re-frame-multi
   "Integration with re-frame, allowing one machine to manage multiple states."
   (:require [re-frame.core :as rf]
+            [re-frame.utils :as rf.utils]
             [statecharts.core :as fsm]
             [statecharts.clock :as clock]
             [statecharts.utils :as u]
@@ -48,6 +49,11 @@
  (fn [db [_ fsm-path]]
    (update-in db (u/ensure-vector fsm-path) #(update % :_epoch inc))))
 
+(rf/reg-event-db
+ ::unregister
+ (fn [db [_ fsm-path]]
+   (rf.utils/dissoc-in db (u/ensure-vector fsm-path))))
+
 (rf/reg-event-fx
  ::initialize
  (fn [{:keys [db]} [_ {:keys [fsm-path state-path clock] :as path-data} initialize-args]]
@@ -91,3 +97,8 @@
                                          (cond-> (assoc fsm-event :data data)
                                            (seq more-data)
                                            (assoc :more-data more-data)))))}))))
+
+(rf/reg-event-db
+ ::discard-state
+ (fn [db [_ state-path]]
+   (rf.utils/dissoc-in db (u/ensure-vector state-path))))

--- a/test/statecharts/integrations/re_frame_multi_test.cljc
+++ b/test/statecharts/integrations/re_frame_multi_test.cljc
@@ -1,0 +1,92 @@
+(ns statecharts.integrations.re-frame-multi-test
+  (:require [re-frame.core :as rf]
+            [statecharts.core :as fsm :refer [assign]]
+            [day8.re-frame.test :refer [run-test-sync]]
+            [statecharts.integrations.re-frame-multi :as fsm.rf]
+            [statecharts.sim :as fsm.sim]
+            [clojure.test :refer [deftest is are use-fixtures testing]]))
+
+(rf/reg-sub
+ :get-data
+ (fn [db [_ key-path]]
+   (get-in db key-path)))
+
+(rf/reg-event-db
+ ::on-friends-loaded
+ (fn [db [_ user _state {:keys [data] :as _event}]]
+   (assoc-in db [:users user :friends] data)))
+
+(def machine-spec
+  {:id      :friends
+   :initial :init
+   :states  {:init        {:after {1000 :loading}}
+             :loading     {:entry (fsm.rf/dispatch-callback :on-loading)
+                           :on    {:success-load {:target :loaded}
+                                   :fail-load    {:target :load-failed}}}
+             :loaded      {:entry (fsm.rf/dispatch-callback :on-success)}
+             :load-failed {:entry (fsm.rf/dispatch-callback :on-error)}}})
+
+(defn get-data [key-path]
+  @(rf/subscribe [:get-data key-path]))
+
+(deftest test-rf-multiple-simultaneous-states
+  (let [clock         (fsm.sim/simulated-clock)
+        advance-clock (fn [ms]
+                        (fsm.sim/advance clock ms))
+        fsm-path      [::fsm :multi]
+
+        transition-data-jack {:fsm-path   fsm-path
+                              :state-path [::fsm-state :jack]}
+        context-jack         {:on-loading [::fsm.rf/transition :success-load transition-data-jack [{:name "jack's friend"}]]
+                              :on-success [::on-friends-loaded "jack"]}
+
+        transition-data-jill {:fsm-path   fsm-path
+                              :state-path [::fsm-state :jill]}
+        context-jill         {:on-loading [::fsm.rf/transition :success-load transition-data-jill [{:name "jill's friend"}]]
+                              :on-success [::on-friends-loaded "jill"]}]
+    (run-test-sync
+     (rf/dispatch [::fsm.rf/register fsm-path (fsm/machine machine-spec)])
+     ;; request jack's friends
+     (rf/dispatch [::fsm.rf/initialize
+                   (assoc transition-data-jack :clock clock)
+                   {:context context-jack}])
+     (is (= (get-data [::fsm-state :jack :_state]) :init))
+     (is (= (get-data [:users "jack" :friends]) nil))
+     (advance-clock 500)
+     ;; a moment later request jill's friends
+     (rf/dispatch [::fsm.rf/initialize
+                   (assoc transition-data-jill :clock clock)
+                   {:context context-jill}])
+     (advance-clock 500)
+     ;; enough time has passed for jack's friends to be fetched
+     (is (= (get-data [::fsm-state :jack :_state]) :loaded))
+     (is (= (get-data [:users "jack" :friends]) [{:name "jack's friend"}]))
+     ;; but jill's request is still pending
+     (is (= (get-data [::fsm-state :jill :_state]) :init))
+     (is (= (get-data [:users "jill" :friends]) nil))
+     ;; until it finishes too
+     (advance-clock 500)
+     (is (= (get-data [::fsm-state :jill :_state]) :loaded))
+     (is (= (get-data [:users "jill" :friends]) [{:name "jill's friend"}])))))
+
+(deftest test-rf-epoch-support
+  (let [clock         (fsm.sim/simulated-clock)
+        advance-clock (fn [ms]
+                        (fsm.sim/advance clock ms))
+        fsm-path      [::fsm :friends]
+
+        state-path      [::fsm-state :jack]
+        transition-data {:fsm-path   fsm-path
+                         :state-path state-path}
+        context         {:on-loading [::fsm.rf/transition :success-load transition-data [{:name "jack's friend"}]]
+                         :on-success [::on-friends-loaded "jack"]}]
+    (run-test-sync
+     (rf/dispatch [::fsm.rf/register fsm-path (fsm/machine machine-spec)])
+     (rf/dispatch [::fsm.rf/initialize
+                   (assoc transition-data :clock clock)
+                   {:context context}])
+     (is (= (get-data [::fsm-state :jack :_state]) :init))
+     (rf/dispatch [::fsm.rf/advance-epoch fsm-path])
+     (advance-clock 1000)
+     ;; :loading transition dropped because of new epoch
+     (is (= (get-data [::fsm-state :jack :_state]) :init)))))


### PR DESCRIPTION
This creates another `re-frame` integration that stores both machines and states in `re-frame`'s app-db. This lets a single machine transition many states and avoids memory leaks when there are hundreds or thousands of states.

I'll summarize here, but for a much more detailed discussion of the problem see [here](https://github.com/ingesolvoll/glimt/pull/3) and [here](https://github.com/ingesolvoll/glimt/discussions/4). /cc @ingesolvoll

In the original integration, `statecharts.integrations.re-frame/integrate` adds event handlers that close over both a `machine` and a `path`. The `path` refers to a _single_ state that is stored within the app-db. The event handlers can manage that one state, but if you want many states you run into problems.

In my case I'm using state machines via [glimt](https://github.com/ingesolvoll/glimt) to track the lifecycle of thousands of separate HTTP requests. Each request has its own state, and there can be many requests in-flight at once. To monitor the progress of each request, I have to create a different machine for each one. I pass those machines to `glimt`, which calls `statecharts.integrations.re-frame/integrate` for each one. But, since that creates new event handlers, and the handlers are stored in `re-frame`'s global handler registry, I end up leaking the memory associated with the handlers and their machines and states. HTTP requests are usually short lived, so I end up with lots of memory consumed for machines and states I no longer care about.

The code in this PR takes a different approach. First, you register a machine, which gets saved in the app-db. Then, you initialize a state, saying where in the app-db you want it to be saved. Over time you can initialize many more states, all using the same machine. Later, you can transition a state by saying where it is in the app db, where its machine is, and what transition you want to call on it. I believe this approach is similar to the concept of "services"—it uses the app-db as a stateful container for immutable states and machines.

With these changes, it's easier to manage memory:
1. No new handlers are registered when you register a machine.
2. A machine can be used many times, instead of once per state.
3. There are tools to remove states and machines from the app-db when they are no longer needed.

A few more notes on the implementation:
* If you'd like to see how I plan to use this integration, see these [proposed changes to `glimt`](https://github.com/mainej/glimt/compare/main...re-frame-multi). I've been working with @ingesolvoll, the maintainer of `glimt` to define this approach. Also see [this gist](https://gist.github.com/mainej/c9621864d3cb7423a1efc8942d65a606) which demonstrates how the new `glimt` code would be used.
* This code includes a change to delayed transitions in `clj-statecharts.impl`, which allows the scheduler to be on either the state (new) or the machine (as before). This lets each state manage how it will be resumed. This should be a non-breaking change. Even if you don't want to maintain the code in this PR as a whole, would you consider merging this part? Then I could maintain this integration in a separate library.
* Related to the above point, I marked the scheduler as internal to the state (by naming it `:_scheduler`). Please correct me if that's wrong.
* I love the `clj-statecharts` docs! They're so clear and detailed. ❤️ If you're interested in merging this PR, I'd be willing to write docs for the new integration. Of course, any guidance about how to write the docs or where to put them would be appreciated.
* I noticed a mismatch between the version of `malli` used in `project.clj` compared to the one in `deps.edn`. I think that will cause problems with the next release of `clj-statecharts`. I'd be happy to help figure out how to make that more maintainable, but that belongs in a separate Issue.