### PR TITLE
Let delayed events be functions of state

### DIFF
--- a/src/statecharts/delayed.cljc
+++ b/src/statecharts/delayed.cljc
@@ -4,13 +4,13 @@
             [statecharts.utils :as u]))
 
 (defprotocol IScheduler
-  (schedule [this event delay])
+  (schedule [this state event delay])
   (unschedule [this event]))
 
 (deftype Scheduler [dispatch ids clock]
   IScheduler
-  (schedule [_ event delay]
-    (let [id (clock/setTimeout clock #(dispatch event) delay)]
+  (schedule [_ state event delay]
+    (let [id (clock/setTimeout clock #(dispatch state event) delay)]
       (swap! ids assoc event id)))
 
   (unschedule [_ event]

--- a/src/statecharts/delayed.cljc
+++ b/src/statecharts/delayed.cljc
@@ -7,22 +7,32 @@
   (schedule [this state event delay])
   (unschedule [this state event]))
 
-(deftype Scheduler [dispatch ids clock]
+(deftype Scheduler [context-id dispatch ids clock]
   IScheduler
   (schedule [_ state event delay]
     (let [id (clock/setTimeout clock #(dispatch state event) delay)]
-      (swap! ids assoc-in [(:_id state) event] id)))
+      (swap! ids assoc-in [(context-id state) event] id)))
 
   (unschedule [_ state event]
-    (when-let [id (get-in @ids [(:_id state) event])]
+    (when-let [id (get-in @ids [(context-id state) event])]
       (clock/clearTimeout clock id)
-      (swap! ids update (:_id state) dissoc event))))
+      (swap! ids update (context-id state) dissoc event))))
 
 (defn scheduler? [x]
   (satisfies? IScheduler x))
 
-(defn make-scheduler [dispatch clock]
-  (Scheduler. dispatch (atom {}) clock))
+(defn make-scheduler
+  ;; By default, a scheduler is not dependent on its context. That is, it expects
+  ;; to dispatch events for only one state. If the machine manages several states,
+  ;; use the arity-3 version.
+  ([dispatch clock]
+   (make-scheduler dispatch clock (constantly :context)))
+  ;; Create a scheduler that can schedule delayed events. When the `clock`
+  ;; determines it is time to invoke a delayed event, `dispatch` will be called.
+  ;; The scheduler can manage delayed events for several states simultaneously.
+  ;; Each is identified by `context-id` (a function of the state context).
+  ([dispatch clock context-id]
+   (Scheduler. context-id dispatch (atom {}) clock)))
 
 (def path-placeholder [:<path>])
 

--- a/src/statecharts/delayed.cljc
+++ b/src/statecharts/delayed.cljc
@@ -14,7 +14,7 @@
       (swap! ids assoc-in [(:_id state) event] id)))
 
   (unschedule [_ state event]
-    (when-let [id (get @ids event)]
+    (when-let [id (get-in @ids [(:_id state) event])]
       (clock/clearTimeout clock id)
       (swap! ids update (:_id state) dissoc event))))
 

--- a/src/statecharts/delayed.cljc
+++ b/src/statecharts/delayed.cljc
@@ -5,18 +5,18 @@
 
 (defprotocol IScheduler
   (schedule [this state event delay])
-  (unschedule [this event]))
+  (unschedule [this state event]))
 
 (deftype Scheduler [dispatch ids clock]
   IScheduler
   (schedule [_ state event delay]
     (let [id (clock/setTimeout clock #(dispatch state event) delay)]
-      (swap! ids assoc event id)))
+      (swap! ids assoc-in [(:_id state) event] id)))
 
-  (unschedule [_ event]
+  (unschedule [_ state event]
     (when-let [id (get @ids event)]
       (clock/clearTimeout clock id)
-      (swap! ids dissoc event))))
+      (swap! ids update (:_id state) dissoc event))))
 
 (defn scheduler? [x]
   (satisfies? IScheduler x))

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -241,7 +241,7 @@
       (fsm.d/schedule scheduler state event event-delay))
 
     (= action :fsm/unschedule-event)
-    (fsm.d/unschedule scheduler event)
+    (fsm.d/unschedule scheduler state event)
 
     :else
     (throw (ex-info (str "Unknown internal action " action) internal-action))))
@@ -816,6 +816,7 @@
          event {:type :fsm/init}
          [_state actions] (-do-init fsm)
          state (assoc context
+                 :_id (u/random-uuid)
                  :_state _state
                  :_actions actions)]
      (if exec

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -808,7 +808,6 @@
      :as fsm}
     {:keys [exec debug id context]
      :or {exec true
-          id (u/random-uuid)
           context nil}
      :as _opts}]
    (let [context (if (some? context)
@@ -817,7 +816,7 @@
          event {:type :fsm/init}
          [_state actions] (-do-init fsm)
          state (assoc context
-                 :_id id
+                 :_id (or id (u/random-uuid))
                  :_state _state
                  :_actions actions)]
      (if exec

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -238,7 +238,7 @@
     (let [event-delay (if (int? event-delay)
                         event-delay
                         (event-delay state transition-event))]
-      (fsm.d/schedule scheduler event event-delay))
+      (fsm.d/schedule scheduler state event event-delay))
 
     (= action :fsm/unschedule-event)
     (fsm.d/unschedule scheduler event)

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -806,8 +806,9 @@
    (initialize fsm nil))
   ([{:keys [initial type]
      :as fsm}
-    {:keys [exec debug context]
+    {:keys [exec debug id context]
      :or {exec true
+          id (u/random-uuid)
           context nil}
      :as _opts}]
    (let [context (if (some? context)
@@ -816,7 +817,7 @@
          event {:type :fsm/init}
          [_state actions] (-do-init fsm)
          state (assoc context
-                 :_id (u/random-uuid)
+                 :_id id
                  :_state _state
                  :_actions actions)]
      (if exec

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -806,7 +806,7 @@
    (initialize fsm nil))
   ([{:keys [initial type]
      :as fsm}
-    {:keys [exec debug id context]
+    {:keys [exec debug context]
      :or {exec true
           context nil}
      :as _opts}]
@@ -816,7 +816,6 @@
          event {:type :fsm/init}
          [_state actions] (-do-init fsm)
          state (assoc context
-                 :_id (or id (u/random-uuid))
                  :_state _state
                  :_actions actions)]
      (if exec

--- a/src/statecharts/integrations/re_frame.cljc
+++ b/src/statecharts/integrations/re_frame.cljc
@@ -44,7 +44,9 @@
     (rf/dispatch [::call-fx effects])))
 
 (defn make-rf-scheduler [transition-event clock]
-  (fsm.d/make-scheduler #(rf/dispatch [transition-event %]) clock))
+  (fsm.d/make-scheduler (fn [_state event]
+                          (rf/dispatch [transition-event event]))
+                        clock))
 
 (defn default-opts []
   {:clock (clock/wall-clock)})

--- a/src/statecharts/integrations/re_frame.cljc
+++ b/src/statecharts/integrations/re_frame.cljc
@@ -44,7 +44,8 @@
     (rf/dispatch [::call-fx effects])))
 
 (defn make-rf-scheduler [transition-event clock]
-  (fsm.d/make-scheduler (fn [_state event]
+  (fsm.d/make-scheduler (fn [_state event] ;; match arity of scheduler dispatch
+                          ;; _state is available but unused by this scheduler
                           (rf/dispatch [transition-event event]))
                         clock))
 

--- a/src/statecharts/service.cljc
+++ b/src/statecharts/service.cljc
@@ -57,6 +57,7 @@
 (defn attach-fsm-scheduler [service fsm]
   (assoc fsm :scheduler (fsm.d/make-scheduler
                          ;; dispatch
-                         #(send service %)
+                         (fn [_state event]
+                           (send service event))
                          ;; clock
                          (.-clock ^Service service))))

--- a/src/statecharts/service.cljc
+++ b/src/statecharts/service.cljc
@@ -57,7 +57,8 @@
 (defn attach-fsm-scheduler [service fsm]
   (assoc fsm :scheduler (fsm.d/make-scheduler
                          ;; dispatch
-                         (fn [_state event]
+                         (fn [_state event] ;; match arity of scheduler dispatch
+                           ;; _state is available but unused by this scheduler
                            (send service event))
                          ;; clock
                          (.-clock ^Service service))))

--- a/src/statecharts/utils.cljc
+++ b/src/statecharts/utils.cljc
@@ -1,5 +1,4 @@
-(ns statecharts.utils
-  (:refer-clojure :exclude [random-uuid]))
+(ns statecharts.utils)
 
 (defn ensure-vector [x]
   (cond
@@ -55,10 +54,3 @@
   (if (= 1 (count x))
     (first x)
     x))
-
-(defn random-uuid
-  "Generates a new random UUID. Same as `cljs.core/random-uuid` except it works
-  for Clojure as well as ClojureScript."
-  []
-  #?(:clj  (java.util.UUID/randomUUID)
-     :cljs (cljs.core/random-uuid)))

--- a/src/statecharts/utils.cljc
+++ b/src/statecharts/utils.cljc
@@ -54,3 +54,10 @@
   (if (= 1 (count x))
     (first x)
     x))
+
+(defn random-uuid
+  "Generates a new random UUID. Same as `cljs.core/random-uuid` except it works
+  for Clojure as well as ClojureScript."
+  []
+  #?(:clj  (java.util.UUID/randomUUID)
+     :cljs (cljs.core/random-uuid)))

--- a/src/statecharts/utils.cljc
+++ b/src/statecharts/utils.cljc
@@ -1,4 +1,5 @@
-(ns statecharts.utils)
+(ns statecharts.utils
+  (:refer-clojure :exclude [random-uuid]))
 
 (defn ensure-vector [x]
   (cond

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -600,7 +600,7 @@
 
         new-state (impl/transition test-machine state :e12)
         new-state2 (impl/transition test-machine new-state :e331)]
-    (is (= new-state
+    (is (= (dissoc new-state :_id)
            {:_state {:p1 :p12
                      :p2 :p23
                      :p3 {:p3.a :p3.a2
@@ -610,7 +610,7 @@
             :b 2
             :c 1
             :d 2}))
-    (is (= new-state2
+    (is (= (dissoc new-state2 :_id)
            {:_state {:p1 :p12
                      :p2 :p23
                      :p3 {:p3.a :p3.a2
@@ -681,7 +681,7 @@
                                      :p3c2.b :p3c2.b1}}}}))
         new-state (impl/transition test-machine state :e12)
         new-state3 (impl/transition test-machine state :e-331out)]
-    (is (= new-state
+    (is (= (dissoc new-state :_id)
            {:_state {:p3 {:p3.a :p3.a2
                           :p3.b :p3.b3
                           :p3.c {:p3c2 {:p3c2.a :p3c2.a1
@@ -695,7 +695,7 @@
                              :cljs js/Error)
                           #"unknown event"
                           (impl/transition test-machine state :e331)))
-    (is (= new-state3
+    (is (= (dissoc new-state3 :_id)
            {:_state [:p2 :p23]
             :a 0
             :b 0

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -1,5 +1,7 @@
 (ns statecharts.impl-test
   (:require [statecharts.impl :as impl :refer [assign]]
+            [statecharts.sim :as fsm.sim]
+            [statecharts.delayed :as fsm.d]
             [clojure.test :refer [deftest is are use-fixtures testing]]
             #?(:clj [kaocha.stacktrace])))
 
@@ -978,3 +980,40 @@
                                       :e12)
                       1000))
   ())
+
+
+(deftest test-simultaneous-delays
+  (let [clock         (fsm.sim/simulated-clock)
+        advance-clock (fn [ms]
+                        (fsm.sim/advance clock ms))
+        states        (atom {})
+        machine       (atom
+                       (impl/machine {:id      :process
+                                      :initial :running
+                                      :states  {:running {:after [{:delay  1000
+                                                                   :target :done}]}
+                                                :done    {}}}))
+
+        scheduler (fsm.d/make-scheduler (fn [state delay-event]
+                                          (swap! states update (:id state)
+                                                 (fn [state]
+                                                   (impl/transition @machine state delay-event))))
+                                        clock)]
+
+    (swap! machine assoc :scheduler scheduler)
+    ;; start one state
+    (swap! states assoc :a
+           (impl/initialize @machine {:context {:id :a}}))
+    (is (= (get-in @states [:a :_state]) :running))
+    (advance-clock 500)
+    ;; a moment later start another
+    (swap! states assoc :b
+           (impl/initialize @machine {:context {:id :b}}))
+    (advance-clock 500)
+    ;; enough time has passed for the first to be done
+    (is (= (get-in @states [:a :_state]) :done))
+    ;; but the second is still pending
+    (is (= (get-in @states [:b :_state]) :running))
+    ;; until it finishes too
+    (advance-clock 500)
+    (is (= (get-in @states [:b :_state]) :done))))

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -981,7 +981,6 @@
                       1000))
   ())
 
-
 (deftest test-simultaneous-delays
   (let [clock         (fsm.sim/simulated-clock)
         advance-clock (fn [ms]

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -600,7 +600,7 @@
 
         new-state (impl/transition test-machine state :e12)
         new-state2 (impl/transition test-machine new-state :e331)]
-    (is (= (dissoc new-state :_id)
+    (is (= new-state
            {:_state {:p1 :p12
                      :p2 :p23
                      :p3 {:p3.a :p3.a2
@@ -610,7 +610,7 @@
             :b 2
             :c 1
             :d 2}))
-    (is (= (dissoc new-state2 :_id)
+    (is (= new-state2
            {:_state {:p1 :p12
                      :p2 :p23
                      :p3 {:p3.a :p3.a2
@@ -681,7 +681,7 @@
                                      :p3c2.b :p3c2.b1}}}}))
         new-state (impl/transition test-machine state :e12)
         new-state3 (impl/transition test-machine state :e-331out)]
-    (is (= (dissoc new-state :_id)
+    (is (= new-state
            {:_state {:p3 {:p3.a :p3.a2
                           :p3.b :p3.b3
                           :p3.c {:p3c2 {:p3c2.a :p3c2.a1
@@ -695,7 +695,7 @@
                              :cljs js/Error)
                           #"unknown event"
                           (impl/transition test-machine state :e331)))
-    (is (= (dissoc new-state3 :_id)
+    (is (= new-state3
            {:_state [:p2 :p23]
             :a 0
             :b 0
@@ -1026,7 +1026,9 @@
                                           (swap! states update (:id state)
                                                  (fn [state]
                                                    (impl/transition @machine state delay-event))))
-                                        clock)]
+                                        clock
+                                        ;; cache timeouts for each state separately
+                                        :id)]
 
     (swap! machine assoc :scheduler scheduler)
     ;; start one state


### PR DESCRIPTION
As discussed in https://github.com/lucywang000/clj-statecharts/pull/7 this PR changes scheduler dispatches by making them functions of a state. This gives delayed events enough information to know what state they are resuming.

~As [mentioned](https://github.com/lucywang000/clj-statecharts/pull/7#issuecomment-954088332), it is not quite working yet. There's a problem if multiple states enter the same delay at the same time.~

~For failing tests, see https://github.com/mainej/clj-statecharts-re-frame. (Run `clj -T:build test`.)~

