### PR TITLE
Structure scheduler to interoperate with data stores (resolves #9)

### DIFF
--- a/docs/content/docs/concepts.md
+++ b/docs/content/docs/concepts.md
@@ -47,7 +47,7 @@ The current state is expressed as a map like this:
   "[context](https://en.wikipedia.org/wiki/UML_state_machine#Extended_states)"
   of the state machine.
 
-## State & Service
+## State & Service {#state-and-service}
 
 How are machine/state connected to the higher level services?
 

--- a/docs/content/docs/stores.md
+++ b/docs/content/docs/stores.md
@@ -3,7 +3,7 @@ title: "Stores"
 ---
 # Stores
 
-clj-statecharts is mostly stateless. But it will often be used in a state-ful environment. The state objects will need to be stored somewhere, either in a [service]({{< relref "/docs/concepts#state-and-service"
+clj-statecharts is mostly stateless. But it will often be used in a state-ful environment. The state objects will need to be stored somewhere, in a [service]({{< relref "/docs/concepts#state-and-service"
 >}}), a [re-frame db]({{< relref "/docs/integration/re-frame"
 >}}), or somewhere of your choosing.
 
@@ -11,5 +11,3 @@ Over time events will transition the state objects, which need to be updated in 
 >}}) clj-statetcharts itself needs to update the storage location in the same way that your code would. clj-statecharts does not dictate how the storage works; instead it provides an interface IStore that lets external transitioners coordinate with the internal delayed transitions to update the storage location in the same way.
 
 Most users of clj-statecharts will not need to understand IStore intimately—they can use a service or one of the existing integrations, which manage an IStore instance internally. However, integration implementors should use this project's examples of how stores are created, connected to schedulers, and used as a facade for `initialize` and `transition`. You can find such examples in the implementation of services, the re-frame integration, and in the tests. Search for `make-store-scheduler`.
-
-

--- a/docs/content/docs/stores.md
+++ b/docs/content/docs/stores.md
@@ -1,0 +1,15 @@
+---
+title: "Stores"
+---
+# Stores
+
+clj-statecharts is mostly stateless. But it will often be used in a state-ful environment. The state objects will need to be stored somewhere, either in a [service]({{< relref "/docs/concepts#state-and-service"
+>}}), a [re-frame db]({{< relref "/docs/integration/re-frame"
+>}}), or somewhere of your choosing.
+
+Over time events will transition the state objects, which need to be updated in the storage location. Much of the time the events will come from your code calling `transition`. In these cases, it might be clear how to update the storage location. However if you use [delayed transitions]({{< relref "/docs/delayed"
+>}}) clj-statetcharts itself needs to update the storage location in the same way that your code would. clj-statecharts does not dictate how the storage works; instead it provides an interface IStore that lets external transitioners coordinate with the internal delayed transitions to update the storage location in the same way.
+
+Most users of clj-statecharts will not need to understand IStore intimately—they can use a service or one of the existing integrations, which manage an IStore instance internally. However, integration implementors should use this project's examples of how stores are created, connected to schedulers, and used as a facade for `initialize` and `transition`. You can find such examples in the implementation of services, the re-frame integration, and in the tests. Search for `make-store-scheduler`.
+
+

--- a/docs/content/menu/index.md
+++ b/docs/content/menu/index.md
@@ -16,3 +16,4 @@ headless = true
   - [Re-frame integration]({{< relref "/docs/integration/re-frame" >}})
 - Internals
   - [Difference from XState]({{< relref "/docs/xstate" >}})
+  - [Stores]({{< relref "/docs/stores" >}})

--- a/src/statecharts/delayed.cljc
+++ b/src/statecharts/delayed.cljc
@@ -4,7 +4,7 @@
 
 (defprotocol IScheduler
   (schedule [this fsm state event delay])
-  (unschedule [this state event]))
+  (unschedule [this fsm state event]))
 
 (defn scheduler? [x]
   (satisfies? IScheduler x))

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -241,7 +241,7 @@
       (fsm.d/schedule scheduler fsm state event event-delay))
 
     (= action :fsm/unschedule-event)
-    (fsm.d/unschedule scheduler state event)
+    (fsm.d/unschedule scheduler fsm state event)
 
     :else
     (throw (ex-info (str "Unknown internal action " action) internal-action))))

--- a/src/statecharts/impl.cljc
+++ b/src/statecharts/impl.cljc
@@ -225,7 +225,7 @@
        (= (some-> (:action action) namespace) "fsm")))
 
 (defn- execute-internal-action
-  [{:as _fsm :keys [scheduler]}
+  [{:as fsm :keys [scheduler]}
    state
    transition-event
    {:as internal-action :keys [action event event-delay]}]
@@ -238,7 +238,7 @@
     (let [event-delay (if (int? event-delay)
                         event-delay
                         (event-delay state transition-event))]
-      (fsm.d/schedule scheduler state event event-delay))
+      (fsm.d/schedule scheduler fsm state event event-delay))
 
     (= action :fsm/unschedule-event)
     (fsm.d/unschedule scheduler state event)

--- a/src/statecharts/scheduler.cljc
+++ b/src/statecharts/scheduler.cljc
@@ -9,7 +9,7 @@
     (let [timeout-id (clock/setTimeout clock #(dispatch fsm state event) delay)]
       (swap! timeout-ids assoc event timeout-id)))
 
-  (unschedule [_ _state event]
+  (unschedule [_ _fsm _state event]
     (when-let [timeout-id (get @timeout-ids event)]
       (clock/clearTimeout clock timeout-id)
       (swap! timeout-ids dissoc event))))
@@ -29,7 +29,7 @@
     (let [state-id   (store/unique-id store state)
           timeout-id (clock/setTimeout clock #(store/transition store fsm state event nil) delay)]
       (swap! timeout-ids assoc-in [state-id event] timeout-id)))
-  (unschedule [_ state event]
+  (unschedule [_ _fsm state event]
     (let [state-id   (store/unique-id store state)
           timeout-id (get-in @timeout-ids [state-id event])]
       (when timeout-id

--- a/src/statecharts/scheduler.cljc
+++ b/src/statecharts/scheduler.cljc
@@ -1,0 +1,46 @@
+(ns statecharts.scheduler
+  (:require [statecharts.store :as store]
+            [statecharts.delayed :as delayed]
+            [statecharts.clock :as clock]))
+
+(deftype Scheduler [dispatch timeout-ids clock]
+  delayed/IScheduler
+  (schedule [_ fsm state event delay]
+    (let [timeout-id (clock/setTimeout clock #(dispatch fsm state event) delay)]
+      (swap! timeout-ids assoc event timeout-id)))
+
+  (unschedule [_ _state event]
+    (when-let [timeout-id (get @timeout-ids event)]
+      (clock/clearTimeout clock timeout-id)
+      (swap! timeout-ids dissoc event))))
+
+(defn ^{:deprecated "0.1.2"} make-scheduler
+  "DEPRECATED: Use [[make-store-scheduler]] instead.
+
+  If we are scheduling events, we must be saving them somewhere, implying that we
+  have a store. make-store-scheduler is a neater combination of those
+  responsibilities: transition and save."
+  ([dispatch clock]
+   (Scheduler. dispatch (atom {}) clock)))
+
+(deftype StoreScheduler [store timeout-ids clock]
+  delayed/IScheduler
+  (schedule [_ fsm state event delay]
+    (let [state-id   (store/unique-id store state)
+          timeout-id (clock/setTimeout clock #(store/transition store fsm state event nil) delay)]
+      (swap! timeout-ids assoc-in [state-id event] timeout-id)))
+  (unschedule [_ state event]
+    (let [state-id   (store/unique-id store state)
+          timeout-id (get-in @timeout-ids [state-id event])]
+      (when timeout-id
+        (clock/clearTimeout clock timeout-id)
+        (swap! timeout-ids update state-id dissoc event)))))
+
+(defn make-store-scheduler
+  "Returns a scheduler that can be used to [[statecharts.delayed/schedule]] events
+  afer some delay. The `store`, which is a `statecharts.store/IStore` contains the
+  current values of the states, and will be updated as those states are
+  transitioned by the scheduled events. The `clock` is part of the delay
+  mechanism."
+  ([store clock]
+   (StoreScheduler. store (atom {}) clock)))

--- a/src/statecharts/service.cljc
+++ b/src/statecharts/service.cljc
@@ -29,7 +29,8 @@
       (store/initialize store fsm nil)))
   (send [_ event]
     (let [old-state (store/get-state store nil)]
-      (store/transition store fsm old-state event transition-opts)))
+      (store/transition store fsm old-state event transition-opts))
+    (store/get-state store nil))
   (add-listener [_ id listener]
     ;; Kind of gross to reach down into the store's internals. Then again, the fact
     ;; that the store is a single-store is an implementation detail known only to

--- a/src/statecharts/service.cljc
+++ b/src/statecharts/service.cljc
@@ -28,9 +28,9 @@
     (let [old-state (store/get-state store nil)]
       (store/transition store fsm old-state event transition-opts)))
   (add-listener [_ id listener]
-    ;; Kind of gross to reach down into store's internals. Then again, the fact
-    ;; that the store a lone-store is an implementation detail known only to this
-    ;; namespace.
+    ;; Kind of gross to reach down into the store's internals. Then again, the fact
+    ;; that the store is a single-store is an implementation detail known only to
+    ;; this namespace.
     (add-watch (:state* store) id (wrap-listener listener)))
   (reload [this fsm_]
     ;; TODO: this is now a no-op. Remove from protocol?
@@ -45,7 +45,7 @@
   ([fsm opts]
    (let [{:keys [clock
                  transition-opts]} (merge (default-opts) opts)
-         store (store/lone-store)]
+         store (store/single-store)]
      (Service. (assoc fsm :scheduler (scheduler/make-store-scheduler store clock))
                ;; state store
                store

--- a/src/statecharts/service.cljc
+++ b/src/statecharts/service.cljc
@@ -1,7 +1,7 @@
 (ns statecharts.service
-  (:require [statecharts.impl :as impl]
-            [statecharts.clock :as clock]
-            [statecharts.delayed :as fsm.d])
+  (:require [statecharts.clock :as clock]
+            [statecharts.store :as store]
+            [statecharts.scheduler :as scheduler])
   (:refer-clojure :exclude [send]))
 
 (defprotocol IService
@@ -10,14 +10,12 @@
   (add-listener [this id listener])
   (reload [this fsm]))
 
-(declare attach-fsm-scheduler)
-
 (defn wrap-listener [f]
   (fn [_ _ old new]
     (f old new)))
 
-(deftype Service [^:volatile-mutable fsm
-                  state
+(deftype Service [fsm
+                  store
                   ^:volatile-mutable running
                   clock
                   transition-opts]
@@ -25,16 +23,17 @@
   (start [this]
     (when-not running
       (set! running true)
-      (set! fsm (attach-fsm-scheduler this fsm))
-      (reset! state (impl/initialize fsm))
-      @state))
+      (store/initialize store fsm nil)))
   (send [_ event]
-    (reset! state (impl/transition fsm @state event transition-opts))
-    @state)
+    (let [old-state (store/get-state store nil)]
+      (store/transition store fsm old-state event transition-opts)))
   (add-listener [_ id listener]
-    (add-watch state id (wrap-listener listener)))
+    ;; Kind of gross to reach down into store's internals. Then again, the fact
+    ;; that the store a lone-store is an implementation detail known only to this
+    ;; namespace.
+    (add-watch (:state* store) id (wrap-listener listener)))
   (reload [this fsm_]
-    (set! fsm (attach-fsm-scheduler this fsm_))
+    ;; TODO: this is now a no-op. Remove from protocol?
     nil))
 
 (defn default-opts []
@@ -45,20 +44,12 @@
    (service fsm nil))
   ([fsm opts]
    (let [{:keys [clock
-                 transition-opts]} (merge (default-opts) opts)]
-     (Service. fsm
-               ;; state
-               (atom nil)
+                 transition-opts]} (merge (default-opts) opts)
+         store (store/lone-store)]
+     (Service. (assoc fsm :scheduler (scheduler/make-store-scheduler store clock))
+               ;; state store
+               store
                ;; running
                false
                clock
                transition-opts))))
-
-(defn attach-fsm-scheduler [service fsm]
-  (assoc fsm :scheduler (fsm.d/make-scheduler
-                         ;; dispatch
-                         (fn [_state event] ;; match arity of scheduler dispatch
-                           ;; _state is available but unused by this scheduler
-                           (send service event))
-                         ;; clock
-                         (.-clock ^Service service))))

--- a/src/statecharts/store.cljc
+++ b/src/statecharts/store.cljc
@@ -21,7 +21,7 @@
     "Get the current value of a state, by its id."))
 
 
-(defrecord LoneStore [state*]
+(defrecord SingleStore [state*]
   IStore
   (unique-id [_ _state] :context)
   (initialize [_ machine opts]
@@ -31,10 +31,10 @@
   (get-state [_ _]
     @state*))
 
-(defn lone-store
-  "A lone-store stores the current value of a single state."
+(defn single-store
+  "A single-store stores the current value of a single state."
   []
-  (LoneStore. (atom nil)))
+  (SingleStore. (atom nil)))
 
 (defrecord ManyStore [states*]
   IStore

--- a/src/statecharts/store.cljc
+++ b/src/statecharts/store.cljc
@@ -1,0 +1,67 @@
+(ns statecharts.store
+  "This namespace provides an interface for a mutable datastore for one or more
+  states.
+
+  It is used in places that are concerned with storing states as they change _over
+  time_. So, [[statecharts.service]], which notifies listeners when a state
+  changes, and [[statecharts.integrations.re-frame]], which persists state changes
+  in a re-frame app-db, both use it. It is also used in [[statecharts.scheduler]],
+  which is concerned with scheduling state changes that will happen at some future
+  time."
+  (:require [statecharts.impl :as impl]))
+
+(defprotocol IStore
+  (unique-id [this state]
+    "Get the id that the store uses to identify this state.")
+  (initialize [this machine opts]
+    "Initialize a state, and save it in the store.")
+  (transition [this machine state event opts]
+    "Transition a state previously saved in the store. Save and return its new value.")
+  (get-state [this id]
+    "Get the current value of a state, by its id."))
+
+
+(defrecord LoneStore [state*]
+  IStore
+  (unique-id [_ _state] :context)
+  (initialize [_ machine opts]
+    (reset! state* (impl/initialize machine opts)))
+  (transition [_ machine _state event opts]
+    (swap! state* #(impl/transition machine % event opts)))
+  (get-state [_ _]
+    @state*))
+
+(defn lone-store
+  "A lone-store stores the current value of a single state."
+  []
+  (LoneStore. (atom nil)))
+
+(defrecord ManyStore [states*]
+  IStore
+  (unique-id [_ state] (:id state))
+  (initialize [this machine opts]
+    (let [state (-> (impl/initialize machine opts)
+                    (update :id #(or % (gensym))))]
+      (swap! states* assoc (unique-id this state) state)
+      state))
+  (transition [this machine state event opts]
+    (let [id (unique-id this state)]
+      (swap! states* update id #(impl/transition machine % event opts))
+      (get-state this id)))
+  (get-state [_ id]
+    (get @states* id)))
+
+(defn many-store
+  "A many-store stores the current values of many states.
+
+  The `opts` provided to `init` should configure the state to have a unique `:id`.
+  This ensures that the state can be transitioned later, even by a scheduler, and
+  is neccessary for calling `get-state`. E.g.
+
+  ```clojure
+  (let [store (store/many-store)]
+    (store/initialize store fsm {:context {:id 1}})
+    (store/get-state store 1))
+  ```"
+  []
+  (ManyStore. (atom {})))

--- a/test/statecharts/impl_test.cljc
+++ b/test/statecharts/impl_test.cljc
@@ -987,7 +987,7 @@
         advance-clock (fn [ms]
                         (fsm.sim/advance clock ms))
         ;; a store that manages a single state
-        state-store   (fsm.store/lone-store)
+        state-store   (fsm.store/single-store)
         machine       (impl/machine
                        {:id        :process
                         :scheduler (fsm.scheduler/make-store-scheduler state-store clock)


### PR DESCRIPTION
I started to pull on the thread described in #9 and got snagged on services. In services, the circular dependency chain is longer. Instead of fsm -> scheduler and back around to -> fsm, we have **service** -> fsm -> scheduler, and back around to -> service.

I decided to step back and articulate the problem a bit better. I've re-described the problem below, and this PR demonstrates a potential solution.

## Problem statement

There are a few situations where this library is asked to store state as it changes over time, including services and the re-frame integration. In the case of a service, transitioned state is saved within the service and passed on to any listeners. In the case of the re-frame integration, state is persisted in re-frame's app-db. To introduce a more generic term, both services and integrations interact with a stateful environment.

Notably, services and integrations are the two situations which permit use of a scheduler. This makes sense—you wouldn't schedule transitions unless you expected the future revised state to interact with the world somehow.

Let's describe a scheduler in more detail. A scheduler has two purposes. First, it provides an interface to schedule a transition at a future time. Second, when that transition runs, it affects its environment somehow. That is, it must store or transmit the new state into a stateful environment.

So, a service or integration and its scheduler both operate on a stateful environment. They must operate in lock-step, each updating the environment in the same way. The first handles transitions initiated externally by an app and the second triggers transitions internally after a delay, but both must affect their environment the same way.

## Implementation Description

This commit introduces the idea of a data `store`: the stateful environment that is updated by transitions. It is a common interface for a service/integration and a scheduler to collaborate around. The two can share a reference to a store, to ensure they both update the environment in the same way. Since the service/integration and scheduler no longer need references to each other, the circular dependency between them described in #9 is broken.

As an aside, this commit also reverts a change introduced in #8 (the expansion of the `make-scheduler` interface to accept a context-id function). In hindsight, that change was trying to teach a scheduler to interact with its environment in the same way that the surrounding service/integration does. With the introduction of a `store`, that coordination is now more strictly enforced. This PR and #8 are both intended to simplify the creation of new integrations, though I think this PR does a more thorough job.